### PR TITLE
Create the `fmt` rule to format our source code using clang-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,3 +163,10 @@ tests:
 # Rule for cleaning the project
 clean:
 	@rm -rvf $(BINDIR)/* $(LIBDIR)/* $(LOGDIR)/*;
+
+# Rule for formatting the source code use clang-format
+fmt:
+	@clang-format -i \
+		-style="{BasedOnStyle: mozilla, IndentWidth: 4, ColumnLimit: 100}" \
+		$(SRCDIR)/*.h \
+		$(SRCDIR)/*.c


### PR DESCRIPTION
Currently, it's very common to have a tool to help us keep the same code style in a project. To accomplish, this PR is introducing `fmt` in our Makefile to help us have clang-format running from the start in a way that new projects can always follow the same code style.

The default style, fixed in the Makefile, is as close as possible to the existing code.